### PR TITLE
Clean off trailing whitespace in the stable version number

### DIFF
--- a/pythonbrew-install
+++ b/pythonbrew-install
@@ -1,7 +1,18 @@
 #!/usr/bin/env bash
 
+shopt -s extglob
+
 PYTHONS="/usr/bin/python /usr/bin/python2 `command -v python`"
 CURL=`command -v curl`
+
+trim()
+{
+    trimmed=$1
+    trimmed="${trimmed#"${trimmed%%[![:space:]]*}"}"   # remove leading whitespace characters
+    trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"   # remove trailing whitespace characters
+
+    echo $trimmed
+}
 
 usage()
 {
@@ -38,13 +49,13 @@ fi
 
 for PYTHON in $PYTHONS ; do
 	if [[ ! -x $PYTHON ]] ; then
-	    continue
+            continue
 	fi
-	
+
 	PYTHON_VERSION=`$PYTHON -V 2>&1`
 	PYTHON_VERSION=${PYTHON_VERSION/"Python "/""}
 	PYTHON_VERSION_S=`echo $PYTHON_VERSION | sed -e "s/\(^[[:digit:]]\{1,\}.[[:digit:]]\{1,\}\).*/\1/"`
-	
+
 	if [[ $PYTHON_VERSION_S = "2.4" ]] || [[ $PYTHON_VERSION_S = "2.5" ]] || [[ $PYTHON_VERSION_S = "2.6" ]] || [[ $PYTHON_VERSION_S = "2.7" ]] ; then
 		PYTHON_FOUND='1'
 		break
@@ -63,6 +74,7 @@ fi
 PATH_DISTS="$ROOT/dists"
 
 STABLE_VERSION=`curl -skL https://github.com/utahta/pythonbrew/raw/master/stable-version.txt`
+STABLE_VERSION=`trim $STABLE_VERSION`
 if [[ $STABLE_VERSION = "" ]] ; then
     echo 'Could not get stable-version of pythonbrew.'
     exit 1


### PR DESCRIPTION
When fetching the stable version number on OSX snow leopard, the following error occurred:

```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
102  2143  102  2143    0     0   2620      0 --:--:-- --:--:-- --:--:--  2620
++ command -v python
+ PYTHONS='/usr/bin/python /usr/bin/python2 /usr/bin/python'
++ command -v curl
+ CURL=/usr/bin/curl
+ parse_arguments
+ [[ ! -x /usr/bin/curl ]]
+ for PYTHON in '$PYTHONS'
+ [[ ! -x /usr/bin/python ]]
++ /usr/bin/python -V
+ PYTHON_VERSION='Python 2.6.1'
+ PYTHON_VERSION=2.6.1
++ echo 2.6.1
++ sed -e 's/\(^[[:digit:]]\{1,\}.[[:digit:]]\{1,\}\).*/\1/'
+ PYTHON_VERSION_S=2.6
+ [[ 2.6 = \2\.\4 ]]
+ [[ 2.6 = \2\.\5 ]]
+ [[ 2.6 = \2\.\6 ]]
+ PYTHON_FOUND=1
+ break
+ [[ 1 != \1 ]]
+ ROOT=/Users/offline/.pythonbrew
+ [[ -n '' ]]
+ PATH_DISTS=/Users/offline/.pythonbrew/dists
++ curl -skL https://github.com/utahta/pythonbrew/raw/master/stable-version.txt
+ STABLE_VERSION=$'0.7.2\r'
 = '' ]].2
+ TEMP_FILE=$'pythonbrew-0.7.2\r'
+ TEMP_TARBALL=$'pythonbrew-0.7.2\r.tar.gz'
+ DOWNLOAD_URL=$'http://pypi.python.org/packages/source/p/pythonbrew/pythonbrew-0.7.2\r.tar.gz'
+ mkdir -p /Users/offline/.pythonbrew/dists
+ rm -rf $'/Users/offline/.pythonbrew/dists/pythonbrew-0.7.2\r.tar.gz'
+ rm -rf $'/Users/offline/.pythonbrew/dists/pythonbrew-0.7.2\r'
.tar.gz'Downloading http://pypi.python.org/packages/source/p/pythonbrew/pythonbrew-0.7.2
.tar.gzding http://pypi.python.org/packages/source/p/pythonbrew/pythonbrew-0.7.2
+ builtin cd /Users/offline/.pythonbrew/dists
+ curl --progress-bar -kL $'http://pypi.python.org/packages/source/p/pythonbrew/pythonbrew-0.7.2\r.tar.gz' -o $'pythonbrew-0.7.2\r.tar.gz'
######################################################################## 100.0%
.tar.gz'Extracting /Users/offline/.pythonbrew/dists/pythonbrew-0.7.2
.tar.gzing /Users/offline/.pythonbrew/dists/pythonbrew-0.7.2
+ builtin cd /Users/offline/.pythonbrew/dists
+ tar zxf $'pythonbrew-0.7.2\r.tar.gz'
tar: Unrecognized archive format: Inappropriate file type or format
tar: Error exit delayed from previous errors.
+ echo 'Installing pythonbrew into /Users/offline/.pythonbrew'
Installing pythonbrew into /Users/offline/.pythonbrew
+ /usr/bin/python $'/Users/offline/.pythonbrew/dists/pythonbrew-0.7.2\r/pythonbrew_install.py'
/pythonbrew_install.py': [Errno 2] No such file or directory/dists/pythonbrew-0.7.2
+ [[ 2 == 1 ]]
```

This happens because the stable version has a trailing `\r` character.

This pull request trims all trailing whitespace from the stable version number, which then works fine
