### PR TITLE
updated config.cfg for Python-3.2.2

### DIFF
--- a/pythonbrew/etc/config.cfg
+++ b/pythonbrew/etc/config.cfg
@@ -184,4 +184,7 @@ url = http://www.python.org/ftp/python/3.2/Python-3.2.tgz
 
 [Python-3.2.1]
 url = http://www.python.org/ftp/python/3.2.1/Python-3.2.1.tgz
+
+[Python-3.2.2]
+url = http://www.python.org/ftp/python/3.2.2/Python-3.2.2.tgz
 latest = True


### PR DESCRIPTION
`pythonbrew install 3.2.2` が失敗していたので Python 3.2.2 用の URL を追加しました。
