### PR TITLE
pythonbrew off also executes deactivate now

### DIFF
--- a/pythonbrew/util.py
+++ b/pythonbrew/util.py
@@ -244,7 +244,7 @@ def is_installed(name):
     
 def set_current_path(path):
     fp = open(PATH_HOME_ETC_CURRENT, 'w')
-    fp.write('PATH_PYTHONBREW_CURRENT="%s"\n' % (path))
+    fp.write('deactivate &> /dev/null\nPATH_PYTHONBREW_CURRENT="%s"\n' % (path))
     fp.close()
 
 def path_to_fileurl(path):


### PR DESCRIPTION
so that the virtualenv is deactivated and the
system gracefully uses system python with global
environment. The system prompt is also updated
as VIRTUAL_ENV is now unset via deactivate.
