### PR TITLE
Python 2.5: Undefine _POSIX_C_SOURCE on Lion to fix 8-byte strings from socket.inet_aton()

### DIFF
--- a/pythonbrew/installer/pythoninstaller.py
+++ b/pythonbrew/installer/pythoninstaller.py
@@ -308,6 +308,7 @@ class PythonInstallerMacOSX(PythonInstaller):
                                                   'patch-setup.py.diff',
                                                   'patch-configure-badcflags.diff',
                                                   'patch-configure-arch_only.diff',
+                                                  'patch-configure-no-posix-c-source.diff',
                                                   'patch-64bit.diff',
                                                   'patch-pyconfig.h.in.diff',
                                                   'patch-gestaltmodule.c.diff',

--- a/pythonbrew/patches/macosx/python25/patch-configure-no-posix-c-source.diff
+++ b/pythonbrew/patches/macosx/python25/patch-configure-no-posix-c-source.diff
@@ -1,0 +1,23 @@
+--- configure.in~       2008-12-14 01:13:52.000000000 +1100
++++ configure.in        2012-05-08 14:32:09.000000000 +1000
+@@ -233,7 +233,7 @@
+   # disables platform specific features beyond repair.
+   # On Mac OS X 10.3, defining _POSIX_C_SOURCE or _XOPEN_SOURCE 
+   # has no effect, don't bother defining them
+-  FreeBSD/4.* | Darwin/@<:@6789@:>@.*)
++  FreeBSD/4.* | Darwin/@<:@6789@:>@.* | Darwin/1@<:@01@:>@.*)
+     define_xopen_source=no;;
+   # On AIX 4 and 5.1, mbstate_t is defined only when _XOPEN_SOURCE == 500 but
+   # used in wcsnrtombs() and mbsnrtowcs() even if _XOPEN_SOURCE is not defined
+
+--- configure~  2008-12-14 01:13:52.000000000 +1000
++++ configure   2012-05-08 14:34:29.000000000 +1000
+@@ -2039,7 +2039,7 @@
+   # disables platform specific features beyond repair.
+   # On Mac OS X 10.3, defining _POSIX_C_SOURCE or _XOPEN_SOURCE
+   # has no effect, don't bother defining them
+-  FreeBSD/4.* | Darwin/[6789].*)
++  FreeBSD/4.* | Darwin/[6789].* | Darwin/1[01].*)
+     define_xopen_source=no;;
+   # On AIX 4 and 5.1, mbstate_t is defined only when _XOPEN_SOURCE == 500 but
+   # used in wcsnrtombs() and mbsnrtowcs() even if _XOPEN_SOURCE is not defined


### PR DESCRIPTION
`socket.inet_aton()` in Python 2.5.6 was returning 8-byte strings when built with Pythonbrew on OS X 10.7.3.  The 8-byte strings were a result of a broken type cast identified in:
- http://bugs.python.org/issue767150
- http://bugs.python.org/issue1008086

Part of the problem was that autoconf was failing to pick up on C lib's `inet_aton()`, exposing the broken type cast mentioned in the bug reports above.  I found an existing precedence for suppressing `_POSIX_C_SOURCE` on older Darwins, which, when extended to cover 10.7.3, magically makes this bug go away.
