### PR TITLE
Fix for #85: Python 2.6.5's SSL Module fails to build on Ubuntu 11.10+

### DIFF
--- a/pythonbrew/installer/pythoninstaller.py
+++ b/pythonbrew/installer/pythoninstaller.py
@@ -128,6 +128,8 @@ class PythonInstaller(object):
             patch_dir = os.path.join(PATH_PATCHES_ALL, "python25")
             self._add_patches_to_list(patch_dir, ['patch-setup.py.diff'])
         elif is_python26(version):
+            patch_dir = os.path.join(PATH_PATCHES_ALL, "python26")
+            self._add_patches_to_list(patch_dir, ['patch-_ssl.c-for-ubuntu-oneiric-and-later.diff'])
             if version < '2.6.6':
                 patch_dir = os.path.join(PATH_PATCHES_ALL, "python26")
                 self._add_patches_to_list(patch_dir, ['patch-setup.py-for-2.6.5-and-earlier.diff'])

--- a/pythonbrew/patches/all/python26/patch-_ssl.c-for-ubuntu-oneiric-and-later.diff
+++ b/pythonbrew/patches/all/python26/patch-_ssl.c-for-ubuntu-oneiric-and-later.diff
@@ -1,0 +1,13 @@
+--- Modules/_ssl.c	2012-06-11 19:18:11.363987131 -0700
++++ Modules/_ssl.c	2012-06-11 19:18:51.639984884 -0700
+@@ -300,8 +300,10 @@
+ 		self->ctx = SSL_CTX_new(TLSv1_method()); /* Set up context */
+ 	else if (proto_version == PY_SSL_VERSION_SSL3)
+ 		self->ctx = SSL_CTX_new(SSLv3_method()); /* Set up context */
++#ifndef OPENSSL_NO_SSL2
+ 	else if (proto_version == PY_SSL_VERSION_SSL2)
+ 		self->ctx = SSL_CTX_new(SSLv2_method()); /* Set up context */
++#endif
+ 	else if (proto_version == PY_SSL_VERSION_SSL23)
+ 		self->ctx = SSL_CTX_new(SSLv23_method()); /* Set up context */
+ 	PySSL_END_ALLOW_THREADS


### PR DESCRIPTION
- Created patch for detecting disabled SSL2 in _ssl.c
- Added patch to pythoninstall script.
## To Test

`python lib/python2.6/test/test_ssl.py`
