### PR TITLE
Documentation for getting libreadline to work

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,15 @@ If you need to install pythonbrew into somewhere else, you can do that by settin
   chmod +x pythonbrewinstall
   ./pythonbrewinstall
 
+Readline Support
+----------------
+
+Python uses a library called `readline` to allow line editing and command history.  If you use Python interactively, it is recommended to install both the `readline` library and its headers.  Otherwise, the arrow keys won't work in the Python interactive shell.
+
+On Debian and Ubuntu systems, the required package is called `libreadline-dev`.  On Fedora, Red Hat, and CentOS, the package is called `readline-devel`.  No extra packages are required on Arch or Gentoo.
+
+The `readline` support package must be installed before Python in order to work properly.
+
 For Systemwide(Multi-User) installation
 ---------------------------------------
 


### PR DESCRIPTION
Python developers are used to having a working libreadline available from within Python, but many are unaware that you need the libreadline headers installed in order to get libreadline working when you compile Python from source.

This expands the documentation to tell users how to get readline working.
