### PR TITLE
Added Python-3.3.0 to config.cfg.

### DIFF
--- a/pythonbrew/etc/config.cfg
+++ b/pythonbrew/etc/config.cfg
@@ -193,4 +193,7 @@ url = http://www.python.org/ftp/python/3.2.2/Python-3.2.2.tgz
 
 [Python-3.2.3]
 url = http://www.python.org/ftp/python/3.2.3/Python-3.2.3.tgz
+
+[Python-3.3.0]
+url = http://www.python.org/ftp/python/3.3.0/Python-3.3.0.tgz
 latest = True


### PR DESCRIPTION
Hello.

I just tried to install Python-3.3.0 with pythonbrew and it didn't work. So, I added Python-3.3.0 to the config.cfg file and it works great.

Brandon
