### PR TITLE
Fix curl version incompatibilities

### DIFF
--- a/pythonbrew-install
+++ b/pythonbrew-install
@@ -79,7 +79,20 @@ else
 fi
 PATH_DISTS="$ROOT/dists"
 
-STABLE_VERSION=`curl -skL https://github.com/utahta/pythonbrew/raw/master/stable-version.txt`
+CURL_VERSION=`$CURL --version | head -n 1 | awk '{ print $2 }'`
+VERSION_ARRAY=(`echo $CURL_VERSION | tr "." "\n"`)
+CURL_MAJOR=${VERSION_ARRAY[0]}
+CURL_MINOR=${VERSION_ARRAY[1]}
+
+echo "Curl version is ${CURL_MAJOR}.${CURL_MINOR}"
+
+CURL_ADDITIONAL_PARAMETERS=""
+
+if (( $CURL_MAJOR >= 7 )) && (( $CURL_MINOR >= 10 )) ; then
+   CURL_PARAMETERS=k
+fi
+
+STABLE_VERSION=`$CURL -sL${CURL_ADDITIONAL_PARAMETERS} https://github.com/utahta/pythonbrew/raw/master/stable-version.txt`
 STABLE_VERSION=`trim $STABLE_VERSION`
 if [[ -z "$STABLE_VERSION" ]] ; then
     echo 'Can not get stable-version of pythonbrew.'
@@ -94,7 +107,7 @@ rm -rf "$PATH_DISTS/$TEMP_TARBALL"
 rm -rf "$PATH_DISTS/$TEMP_FILE"
 
 echo "Downloading $DOWNLOAD_URL"
-builtin cd $PATH_DISTS ; curl --progress-bar -kL $DOWNLOAD_URL -o "$TEMP_TARBALL"
+builtin cd $PATH_DISTS ; $CURL --progress-bar -L${CURL_ADDITIONAL_PARAMETERS} $DOWNLOAD_URL -o "$TEMP_TARBALL"
 
 echo "Extracting $PATH_DISTS/$TEMP_TARBALL"
 builtin cd $PATH_DISTS ; tar zxf $TEMP_TARBALL


### PR DESCRIPTION
Hello,

Please integrate this patch, this fixes issue https://github.com/utahta/pythonbrew/issues/105

This code uses -k parameter only for curl >= 7.10

Tested with curl 7.19 and 7.9 (so with and without triggering this fix)

Regards,
