### PR TITLE
Fix compilation of Python 2.6.2 and earlier.

### DIFF
--- a/pythonbrew/installer/pythoninstaller.py
+++ b/pythonbrew/installer/pythoninstaller.py
@@ -130,6 +130,8 @@ class PythonInstaller(object):
         elif is_python26(version):
             if version < '2.6.6':
                 patch_dir = os.path.join(PATH_PATCHES_ALL, "python26")
+                if version < '2.6.3':
+                    self._add_patches_to_list(patch_dir, ['patch-Makefile.pre.in-for-2.6.2-and-earlier.diff'])
                 self._add_patches_to_list(patch_dir, ['patch-setup.py-for-2.6.5-and-earlier.diff'])
                 self._add_patches_to_list(patch_dir, ['patch-_ssl.c-for-ubuntu-oneiric-and-later.diff'])
             else:

--- a/pythonbrew/patches/all/python26/patch-Makefile.pre.in-for-2.6.2-and-earlier.diff
+++ b/pythonbrew/patches/all/python26/patch-Makefile.pre.in-for-2.6.2-and-earlier.diff
@@ -1,0 +1,11 @@
+--- Makefile.pre.in.orig	2013-03-19 23:11:41.577326000 +0100
++++ Makefile.pre.in	2013-03-19 23:12:06.297327012 +0100
+@@ -497,7 +497,7 @@
+ 		$(SIGNAL_OBJS) \
+ 		$(MODOBJS) \
+ 		$(srcdir)/Modules/getbuildinfo.c
+-	$(CC) -c $(PY_CFLAGS) -DSVNVERSION=\"`LC_ALL=C $(SVNVERSION)`\" -o $@ $(srcdir)/Modules/getbuildinfo.c
++	$(CC) -c $(PY_CFLAGS) -DSVNVERSION="\"`LC_ALL=C $(SVNVERSION)`\"" -o $@ $(srcdir)/Modules/getbuildinfo.c
+ 
+ Modules/getpath.o: $(srcdir)/Modules/getpath.c Makefile
+ 	$(CC) -c $(PY_CFLAGS) -DPYTHONPATH='"$(PYTHONPATH)"' \


### PR DESCRIPTION
Hi, compilation of python 2.6 through 2.6.2 fails on linux due to a couple of missing quotes in Makefile.pre.in, so I committed this trivial fix.
Thank you for this useful software.
