### PR TITLE
remove venv create -n option; add a venv create -g option which means gi...

### DIFF
--- a/pythonbrew/commands/venv.py
+++ b/pythonbrew/commands/venv.py
@@ -13,7 +13,7 @@ class VenvCommand(Command):
     name = "venv"
     usage = "%prog [create|use|delete|list|clone|rename|print_activate] [project]"
     summary = "Create isolated python environments"
-    
+
     def __init__(self):
         super(VenvCommand, self).__init__()
         self.parser.add_option(
@@ -24,18 +24,18 @@ class VenvCommand(Command):
             metavar='VERSION'
         )
         self.parser.add_option(
-            "-n", "--no-site-packages",
-            dest="no_site_packages",
+            "-g", "--system-site-packages",
+            dest="system_site_packages",
             action='store_true',
             default=False,
-            help="Don't give access to the global site-packages dir to the virtual environment.",
+            help="Give access to the global site-packages dir to the virtual environment.",
         )
         self._venv_dir = os.path.join(PATH_ETC, 'virtualenv')
         self._venv = os.path.join(self._venv_dir, 'virtualenv.py')
         self._venv_clone_dir = os.path.join(PATH_ETC, 'virtualenv-clone')
         self._venv_clone = os.path.join(self._venv_clone_dir, 'clonevirtualenv.py')
         self._clear()
-        
+
     def run_command(self, options, args):
         if not args:
             self.parser.print_help()
@@ -44,12 +44,12 @@ class VenvCommand(Command):
         if not cmd in ('init', 'create', 'delete', 'use', 'list', 'clone', 'rename', 'print_activate'):
             self.parser.print_help()
             sys.exit(1)
-        
+
         # initialize?
         if cmd == 'init':
             self.run_command_init()
             return
-        
+
         # target python interpreter
         if options.python:
             pkgname = Package(options.python).name
@@ -58,20 +58,20 @@ class VenvCommand(Command):
                 sys.exit(1)
         else:
             pkgname = get_using_python_pkgname()
-        
+
         self._pkgname = pkgname
         if self._pkgname:
             self._target_py = os.path.join(PATH_PYTHONS, pkgname, 'bin', 'python')
             self._workon_home = os.path.join(PATH_VENVS, pkgname)
             self._py = os.path.join(PATH_PYTHONS, pkgname, 'bin', 'python')
-        
+
         # is already installed virtualenv?
         if not os.path.exists(self._venv) or not os.path.exists(self._venv_clone):
             self.run_command_init()
-        
+
         # Create a shell script
         self.__getattribute__('run_command_%s' % cmd)(options, args)
-    
+
     def run_command_init(self):
         if os.path.exists(self._venv):
             logger.info('Remove virtualenv. (%s)' % self._venv_dir)
@@ -91,7 +91,7 @@ class VenvCommand(Command):
         d.download('virtualenv-clone.tar.gz', VIRTUALENV_CLONE_DLSITE, download_file)
         logger.info('Extracting virtualenv-clone into %s' % self._venv_clone_dir)
         untar_file(download_file, self._venv_clone_dir)
-        
+
     def run_command_create(self, options, args):
         if not os.access(PATH_VENVS, os.W_OK):
             logger.error("Can not create a virtual environment in %s.\nPermission denied." % PATH_VENVS)
@@ -99,11 +99,11 @@ class VenvCommand(Command):
         if not self._pkgname:
             logger.error("Unknown python version: ( 'pythonbrew venv create <project> -p VERSION' )")
             sys.exit(1)
-        
+
         virtualenv_options = []
-        if options.no_site_packages:
-            virtualenv_options.append('--no-site-packages')
-        
+        if options.system_site_packages:
+            virtualenv_options.append('--system-site-packages')
+
         for arg in args[1:]:
             target_dir = os.path.join(self._workon_home, arg)
             logger.info("Creating `%s` environment into %s" % (arg, self._workon_home))
@@ -114,12 +114,12 @@ class VenvCommand(Command):
             # create environment
             s = Subprocess(verbose=True)
             s.call(cmd)
-    
+
     def run_command_delete(self, options, args):
         if not self._pkgname:
             logger.error("Unknown python version: ( 'pythonbrew venv delete <project> -p VERSION' )")
             sys.exit(1)
-        
+
         for arg in args[1:]:
             target_dir = os.path.join(self._workon_home, arg)
             if not os.path.isdir(target_dir):
@@ -131,12 +131,12 @@ class VenvCommand(Command):
                 logger.info('Deleting `%s` environment in %s' % (arg, self._workon_home))
                 # make command
                 rm_r(target_dir)
-    
+
     def run_command_use(self, options, args):
         if len(args) < 2:
             logger.error("Unrecognized command line argument: ( 'pythonbrew venv use <project>' )")
             sys.exit(1)
-        
+
         workon_home = None
         activate = None
         if self._pkgname:
@@ -152,13 +152,13 @@ class VenvCommand(Command):
         if not activate or not os.path.exists(activate):
             logger.error('`%s` environment does not exist. Try `pythonbrew venv create %s`.' % (args[1], args[1]))
             sys.exit(1)
-        
+
         self._write("""\
 echo '# Using `%(arg)s` environment (found in %(workon_home)s)'
 echo '# To leave an environment, simply run `deactivate`'
 source '%(activate)s'
 """ % {'arg': args[1], 'workon_home': workon_home, 'activate': activate})
-    
+
     def run_command_list(self, options, args):
         if options.python:
             pkgname = Package(options.python).name
@@ -184,7 +184,7 @@ source '%(activate)s'
                         for d in sorted(dirs):
                             if os.path.isdir(os.path.join(workon_home, d)):
                                 logger.log("  %s" % d)
-    
+
     def run_command_clone(self, options, args):
         if len(args) < 3:
             logger.error("Unrecognized command line argument: ( 'pythonbrew venv clone <source> <target>' )")
@@ -195,11 +195,11 @@ source '%(activate)s'
         if not self._pkgname:
             logger.error("Unknown python version: ( 'pythonbrew venv clone <source> <target> -p VERSION' )")
             sys.exit(1)
-        
+
         source, target = args[1], args[2]
         source_dir = os.path.join(self._workon_home, source)
         target_dir = os.path.join(self._workon_home, target)
-        
+
         if not os.path.isdir(source_dir):
             logger.error('%s does not exist.' % source_dir)
             sys.exit(1)
@@ -207,9 +207,9 @@ source '%(activate)s'
         if os.path.isdir(target_dir):
             logger.error('Can not overwrite %s.' % target_dir)
             sys.exit(1)
-        
+
         logger.info("Cloning `%s` environment into `%s` on %s" % (source, target, self._workon_home))
-        
+
         # Copies source to target
         cmd = [self._py, self._venv_clone, source_dir, target_dir]
         s = Subprocess()
@@ -225,13 +225,13 @@ source '%(activate)s'
         if not self._pkgname:
             logger.error("Unknown python version: ( 'pythonbrew venv rename <source> <target> -p VERSION' )")
             sys.exit(1)
-        
+
         logger.info("Rename `%s` environment to `%s` on %s" % (args[1], args[2], self._workon_home))
 
         source, target = args[1], args[2]
         self.run_command_clone(options, ['clone', source, target])
         self.run_command_delete(options, ['delete', source])
-    
+
     def run_command_print_activate(self, options, args):
         if len(args) < 2:
             logger.error("Unrecognized command line argument: ( 'pythonbrew venv print_activate <project>' )")
@@ -239,20 +239,20 @@ source '%(activate)s'
         if not self._pkgname:
             logger.error("Unknown python version: ( 'pythonbrew venv print_activate <project> -p VERSION' )")
             sys.exit(1)
-        
+
         activate = os.path.join(self._workon_home, args[1], 'bin', 'activate')
         if not os.path.exists(activate):
             logger.error('`%s` environment already does not exist. Try `pythonbrew venv create %s`.' % (args[1], args[1]))
             sys.exit(1)
-            
+
         logger.log(activate)
-    
+
     def _clear(self):
         self._write("")
-    
+
     def _write(self, src):
         fp = open(PATH_HOME_ETC_VENV, 'w')
         fp.write(src)
         fp.close()
-    
+
 VenvCommand()


### PR DESCRIPTION
remove venv create -n option; add a venv create -g option which means give access to the global site-packages dir to the vitrualenv; the previous -n option is now the default behaviour in recent version of virtualenv

`--no-site-packages` option of virtualenv is deprecated and made to the default behaviour. [See here](https://github.com/pypa/virtualenv/blob/develop/virtualenv.py#L835). Meanwhile, a `--system-site-packages` option is added. virtualenv 1.8.4 used by pythonbrew has already made this change. I remove the -n option and add a -g option to create a venv with the `--system-site-packages` option.
