### PR TITLE
Add Python 2.7.6 as latest 2.x release

### DIFF
--- a/pythonbrew/etc/config.cfg
+++ b/pythonbrew/etc/config.cfg
@@ -169,6 +169,9 @@ url = http://www.python.org/ftp/python/2.7.4/Python-2.7.4.tgz
 
 [Python-2.7.5]
 url = http://www.python.org/ftp/python/2.7.5/Python-2.7.5.tgz
+
+[Python-2.7.6]
+url = http://www.python.org/ftp/python/2.7.6/Python-2.7.6.tgz
 latest = True
 
 [Python-3.0]


### PR DESCRIPTION
For some reason, specifying a URL directly on the command line didn't work for me. I realize you aren't maintaining this code anymore, so feel free to ignore. This just adds 2.7.6 as the latest Python 2.x release.
