### PR TITLE
fix syntax error in pythonbrew/etc/bashrc

### DIFF
--- a/pythonbrew/etc/bashrc
+++ b/pythonbrew/etc/bashrc
@@ -23,7 +23,9 @@ __pythonbrew_set_default()
 
 __pythonbrew_set_path()
 {
-    PATH_WITHOUT_PYTHONBREW=$(printf "$PATH" | awk -v RS=: -v ORS=: "/${PATH_ROOT//\//\/}/ {next} {print}" | sed -e 's#:$##')
+    PATH_WITHOUT_PYTHONBREW=$(printf "%s" "$PATH" |
+    awk -v path_root="${PATH_ROOT//\//\/}" 'BEGIN{RS=ORS=":"} $0 !~ path_root' |
+    sed -e 's#:$##')
     export PATH=$PATH_PYTHONBREW:$PATH_WITHOUT_PYTHONBREW
     export PYTHONPATH=$PATH_PYTHONBREW_LIB
 }


### PR DESCRIPTION
After upgrading to Ubuntu 14.04, dash is not happy, see [this stackoverflow question](http://stackoverflow.com/questions/22768854/pythonbrew-bashrc-awk-line-no-longer-works). [This answer](http://stackoverflow.com/a/22774174/1582182) from user [Ed Morton](http://stackoverflow.com/users/1745001/ed-morton) solves the issue.
