### PR TITLE
Update config.cfg

### DIFF
--- a/pythonbrew/etc/config.cfg
+++ b/pythonbrew/etc/config.cfg
@@ -1,5 +1,6 @@
 [distribute]
-url = http://python-distribute.org/distribute_setup.py
+#url = http://python-distribute.org/distribute_setup.py
+url = https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py
 
 [bootstrap]
 url = http://svn.zope.org/*checkout*/zc.buildout/trunk/bootstrap/bootstrap.py
@@ -178,6 +179,15 @@ url = http://www.python.org/ftp/python/2.7.6/Python-2.7.6.tgz
 
 [Python-2.7.7]
 url = http://www.python.org/ftp/python/2.7.7/Python-2.7.7.tgz
+
+[Python-2.7.8]
+url = http://www.python.org/ftp/python/2.7.8/Python-2.7.8.tgz
+ 
+[Python-2.7.9]
+url = http://www.python.org/ftp/python/2.7.9/Python-2.7.9.tgz
+ 
+[Python-2.7.10]
+url = http://www.python.org/ftp/python/2.7.10/Python-2.7.10.tgz
 latest = True
 
 [Python-3.0]
@@ -249,4 +259,10 @@ url = http://www.python.org/ftp/python/3.4.0/Python-3.4.0.tgz
 
 [Python-3.4.1]
 url = http://www.python.org/ftp/python/3.4.1/Python-3.4.1.tgz
+ 
+[Python-3.4.2]
+url = http://www.python.org/ftp/python/3.4.2/Python-3.4.2.tgz
+ 
+[Python-3.4.3]
+url = http://www.python.org/ftp/python/3.4.3/Python-3.4.3.tgz
 latest = True


### PR DESCRIPTION
2013年に distribute は setuptools にマージされた のでその対応。
Python-2.7.10、Python-3.4.3に対応。
動作確認はしていますが、これで良いでしょうか？
http://www.tomoyan.net/dokuwiki/python/pythonbrew