### PR TITLE
chore: the argument is already a string, there's no need to use fmt.S…

### DIFF
--- a/subcmd/list.go
+++ b/subcmd/list.go
@@ -81,7 +81,7 @@ func (c *List) Run(args []string) error {
 			if filepath.Join(path.InstallDir(), f.Name()) == current {
 				name = color.New(color.FgYellow, color.BgBlack).Sprintf("%s", f.Name())
 			} else {
-				name = fmt.Sprintf("%s", f.Name())
+				name = f.Name()
 			}
 			c.log.Printf(name)
 		}


### PR DESCRIPTION
…printf